### PR TITLE
Fix deployment script to use correct deployer address

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -16,9 +16,10 @@ contract Deploy is Script {
 
     // Start broadcasting transactions
     vm.startBroadcast(deployerPrivateKey);
+    address deployer = vm.addr(deployerPrivateKey);
 
     // Deploy the factory
-    factory = new QueryTypeStakerFactory(msg.sender, wTokenAddress);
+    factory = new QueryTypeStakerFactory(deployer, wTokenAddress);
 
     vm.stopBroadcast();
   }


### PR DESCRIPTION
The existing script deploys the contract using the Forge deployment address rather than with the key provided.