### PR TITLE
Fix claim underflow after accessEnd

### DIFF
--- a/src/QueryTypeStakingPool.sol
+++ b/src/QueryTypeStakingPool.sol
@@ -348,11 +348,17 @@ contract QueryTypeStakingPool is Ownable {
     StakeInfo memory _stakeInfo = stakes[_staker];
     if (_stakeInfo.amount == 0) return _stakeInfo;
 
+    if (_stakeInfo.lastClaimed >= _stakeInfo.accessEnd) return _stakeInfo;
+
     uint256 _elapsed = block.timestamp - _stakeInfo.lastClaimed;
     if (_elapsed == 0) return _stakeInfo;
 
     uint256 _totalPeriod = _stakeInfo.accessEnd - _stakeInfo.lastClaimed;
     if (_totalPeriod == 0) return _stakeInfo;
+
+    if (block.timestamp > _stakeInfo.accessEnd) {
+      _elapsed = _stakeInfo.accessEnd - _stakeInfo.lastClaimed;
+    }
 
     uint256 _maxDecay = (_stakeInfo.amount * _elapsed) / _totalPeriod;
 
@@ -373,11 +379,17 @@ contract QueryTypeStakingPool is Ownable {
     StakeInfo storage stakeInfo = stakes[_staker];
     if (stakeInfo.amount == 0) return 0;
 
+    if (stakeInfo.lastClaimed >= stakeInfo.accessEnd) return 0;
+
     uint256 _elapsed = block.timestamp - stakeInfo.lastClaimed;
     if (_elapsed == 0) return 0;
 
     uint256 _totalPeriod = stakeInfo.accessEnd - stakeInfo.lastClaimed;
     if (_totalPeriod == 0) return 0;
+
+    if (block.timestamp > stakeInfo.accessEnd) {
+      _elapsed = stakeInfo.accessEnd - stakeInfo.lastClaimed;
+    }
 
     uint256 _maxDecay = (stakeInfo.amount * _elapsed) / _totalPeriod;
 
@@ -392,7 +404,8 @@ contract QueryTypeStakingPool is Ownable {
 
     // Apply decay and update accounting
     stakeInfo.amount -= _decayed;
-    stakeInfo.lastClaimed = uint48(block.timestamp);
+    stakeInfo.lastClaimed =
+      uint48(block.timestamp > stakeInfo.accessEnd ? stakeInfo.accessEnd : block.timestamp);
 
     address _feeRecipient = QueryTypeStakerFactory(FACTORY).feeRecipient();
     STAKING_TOKEN.safeTransfer(_feeRecipient, _decayed);

--- a/test/QueryTypeStakingPool.t.sol
+++ b/test/QueryTypeStakingPool.t.sol
@@ -1476,6 +1476,32 @@ contract Claim is QueryTypeStakingPoolTest {
     assertEq(balanceAfter - balanceBefore, 0, "0% decay rate should lose nothing");
   }
 
+  function test_ClaimAfterAccessEndDoesNotLockUnstake() public {
+    QueryTypeStakingPool poolOnePercent = _deployPool(1);
+    vm.prank(staker);
+    stakingToken.approve(address(poolOnePercent), type(uint256).max);
+    poolOnePercent.setStakingTokenCapacity(type(uint256).max);
+
+    vm.prank(staker);
+    poolOnePercent.stake(100 ether);
+
+    QueryTypeStakingPool.StakeInfo memory stakeInfo = _getStakeInfoFromPool(poolOnePercent, staker);
+
+    vm.warp(stakeInfo.accessEnd + 1);
+
+    address attacker = makeAddr("attacker");
+    vm.prank(attacker);
+    poolOnePercent.claim(staker);
+
+    vm.warp(block.timestamp + 1);
+
+    // Should not revert after the fix
+    poolOnePercent.getStakeInfo(staker);
+
+    vm.prank(staker);
+    poolOnePercent.unstake(1 ether);
+  }
+
   function _getStakeInfoFromPool(QueryTypeStakingPool _pool, address _staker)
     internal
     view


### PR DESCRIPTION
## Summary
Fixes a critical lockout where any address can permanently lock another staker’s remaining funds (for pools with DECAY_RATE < 100) by calling `claim` after `accessEnd`, which sets `lastClaimed` to `block.timestamp > accessEnd`. Subsequent `_claimDecay` (and `getStakeInfo`) underflows on `accessEnd - lastClaimed`, reverting, and `unstake` always calls `_claimDecay` first, so the stake becomes unwithdrawable.

## Fix
Clamp decay to the access window and prevent `lastClaimed` from exceeding `accessEnd` in both `getStakeInfo` and `_claimDecay`.

## Tests
- `forge test --match-test test_ClaimAfterAccessEndDoesNotLockUnstake`