### PR TITLE
Fix/decay division by zero

### DIFF
--- a/src/QueryTypeStakerFactory.sol
+++ b/src/QueryTypeStakerFactory.sol
@@ -38,7 +38,7 @@ contract QueryTypeStakerFactory is Ownable {
   /// @notice Thrown when the decay rate encoded in query type exceeds 100.
   error QueryTypeStakerFactory__InvalidDecayRate();
 
-  /// @notice Thrown when both lockup and access periods are zero.
+  /// @notice  Thrown when either lockup or access period is zero.
   error QueryTypeStakerFactory__InvalidPeriodConfig();
 
   /// @notice Constructor that sets the initial owner and staking token.

--- a/src/QueryTypeStakerFactory.sol
+++ b/src/QueryTypeStakerFactory.sol
@@ -38,6 +38,9 @@ contract QueryTypeStakerFactory is Ownable {
   /// @notice Thrown when the decay rate encoded in query type exceeds 100.
   error QueryTypeStakerFactory__InvalidDecayRate();
 
+  /// @notice Thrown when both lockup and access periods are zero.
+  error QueryTypeStakerFactory__InvalidPeriodConfig();
+
   /// @notice Constructor that sets the initial owner and staking token.
   /// @param _owner The address that will be set as the contract owner.
   /// @param _stakingToken The address of the Wormhole token that will be used for staking.
@@ -74,6 +77,11 @@ contract QueryTypeStakerFactory is Ownable {
 
     // Validate decay rate is within bounds (0-100)
     if (_decayRate > 100) revert QueryTypeStakerFactory__InvalidDecayRate();
+
+    // Validate that both periods are not zero
+    if (_lockupPeriod == 0 || _accessPeriod == 0) {
+      revert QueryTypeStakerFactory__InvalidPeriodConfig();
+    }
 
     // Deploy new staking pool with STAKING_TOKEN address and initial conversion entry
     QueryTypeStakingPool _newPool = new QueryTypeStakingPool(

--- a/src/QueryTypeStakingPool.sol
+++ b/src/QueryTypeStakingPool.sol
@@ -159,6 +159,9 @@ contract QueryTypeStakingPool is Ownable {
   /// @notice Thrown when trying to stake from a blocklisted address
   error QueryTypeStakingPool__AddressBlocklisted();
 
+  /// @notice Thrown when both lockup and access periods are zero.
+  error QueryTypeStakingPool__InvalidPeriodConfig();
+
   /// @notice Initializes the contract with the staking token address and initial conversion table
   /// entry.
   /// @param _owner The address that will own the contract and have permission to update the
@@ -418,6 +421,7 @@ contract QueryTypeStakingPool is Ownable {
   /// @notice Internal function to set the lockup period.
   /// @param _period The new lockup period in seconds.
   function _setLockupPeriod(uint48 _period) internal {
+    if (_period == 0) revert QueryTypeStakingPool__InvalidPeriodConfig();
     lockupPeriod = _period;
     emit LockupPeriodUpdated(_period);
   }
@@ -425,6 +429,7 @@ contract QueryTypeStakingPool is Ownable {
   /// @notice Internal function to set the access period.
   /// @param _period The new access period in seconds.
   function _setAccessPeriod(uint48 _period) internal {
+    if (_period == 0) revert QueryTypeStakingPool__InvalidPeriodConfig();
     accessPeriod = _period;
     emit AccessPeriodUpdated(_period);
   }

--- a/src/QueryTypeStakingPool.sol
+++ b/src/QueryTypeStakingPool.sol
@@ -159,7 +159,7 @@ contract QueryTypeStakingPool is Ownable {
   /// @notice Thrown when trying to stake from a blocklisted address
   error QueryTypeStakingPool__AddressBlocklisted();
 
-  /// @notice Thrown when both lockup and access periods are zero.
+  /// @notice Thrown when a lockup or access period is zero.
   error QueryTypeStakingPool__InvalidPeriodConfig();
 
   /// @notice Initializes the contract with the staking token address and initial conversion table

--- a/test/QueryTypeStakingPool.t.sol
+++ b/test/QueryTypeStakingPool.t.sol
@@ -262,8 +262,8 @@ contract Stake is QueryTypeStakingPoolTest {
     uint256 _capacity
   ) public {
     _amount = bound(_amount, 1, INITIAL_BALANCE);
-    _newLockupPeriod = uint48(bound(_newLockupPeriod, 0, 1000 days));
-    _newAccessPeriod = uint48(bound(_newAccessPeriod, 0, 1000 days));
+    _newLockupPeriod = uint48(bound(_newLockupPeriod, 1, 1000 days));
+    _newAccessPeriod = uint48(bound(_newAccessPeriod, 1, 1000 days));
     _capacity = bound(_capacity, _amount, type(uint256).max);
 
     pool.setStakingTokenCapacity(_capacity);
@@ -486,11 +486,13 @@ contract SetMinimumStake is QueryTypeStakingPoolTest {
 
 contract SetLockupPeriod is QueryTypeStakingPoolTest {
   function testFuzz_SetLockupPeriodSuccessfully(uint48 _newPeriod) public {
+    _newPeriod = uint48(bound(_newPeriod, 1, 1000 days));
     pool.setLockupPeriod(_newPeriod);
     assertEq(pool.lockupPeriod(), _newPeriod);
   }
 
   function testFuzz_SetLockupPeriodEmitsEvent(uint48 _newPeriod) public {
+    _newPeriod = uint48(bound(_newPeriod, 1, 1000 days));
     vm.expectEmit();
     emit QueryTypeStakingPool.LockupPeriodUpdated(_newPeriod);
 
@@ -507,11 +509,13 @@ contract SetLockupPeriod is QueryTypeStakingPoolTest {
 
 contract SetAccessPeriod is QueryTypeStakingPoolTest {
   function testFuzz_SetAccessPeriodSuccessfully(uint48 _newPeriod) public {
+    _newPeriod = uint48(bound(_newPeriod, 1, 1000 days));
     pool.setAccessPeriod(_newPeriod);
     assertEq(pool.accessPeriod(), _newPeriod);
   }
 
   function testFuzz_SetAccessPeriodEmitsEvent(uint48 _newPeriod) public {
+    _newPeriod = uint48(bound(_newPeriod, 1, 1000 days));
     vm.expectEmit();
     emit QueryTypeStakingPool.AccessPeriodUpdated(_newPeriod);
 


### PR DESCRIPTION
## Summary
Fixes a critical configuration vulnerability where a pool can be rendered permanently unusable ("bricked") if both lockupPeriod and accessPeriod are set to zero. This configuration results in _totalPeriod being calculated as 0 within _claimDecay. Consequently, any call to stake() or unstake() triggers a division-by-zero panic during the _maxDecay calculation, locking all user funds and preventing any further state transitions for that pool.

##Fix
Implemented the validation check